### PR TITLE
Add the possibility to include actions with an attachment

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -92,6 +92,17 @@ class Attachment {
     public $thumbUrl;
 
     /**
+     * Optional actions that can be made when responding to an incoming attachment. Should be an array that includes:
+     * 'name' string Title of an action button (ex. Verify)
+     * 'integration' array:
+     *      'url' string URL where the action will be sent (ex. https://opt.netis.pl/mattermost/verify-request)
+     *      'context' array: include any parameters that will be sent to the URL (ex. ['text' => 123456]
+     *
+     * @var array
+     */
+    public $actions = [];
+
+    /**
      * @param  string  $fallback
      * @return $this
      */
@@ -263,6 +274,20 @@ class Attachment {
     public function thumbUrl($thumbUrl)
     {
         $this->thumbUrl = $thumbUrl;
+
+        return $this;
+    }
+
+    public function action($action)
+    {
+        $this->actions[] = $action;
+
+        return $this;
+    }
+
+    public function actions($actions)
+    {
+        $this->actions = $actions;
 
         return $this;
     }

--- a/src/Mattermost.php
+++ b/src/Mattermost.php
@@ -51,6 +51,7 @@ class Mattermost {
                 'fields' => $attachment->fields,
                 'image_url' => $attachment->imageUrl,
                 'thumb_url' => $attachment->thumbUrl,
+                'actions' => $attachment->actions,
             ]);
         }, $message->attachments);
     }


### PR DESCRIPTION
In order to use Mattermost Interactive Message Buttons (https://docs.mattermost.com/developer/interactive-message-buttons.html), there's a need for an 'actions' field. This merge requests adds the possibility to add actions with an attachment. 